### PR TITLE
Replace rn-fetch-blob with react-native-blob-util

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,10 +4,10 @@ Use direct upload for uploading files to Rails ActiveStorage.
 
 ## Installation
 
-Install this package and [rn-fetch-blob](rn-fetch-blob)
+Install this package and [react-native-blob-util](react-native-blob-util)
 
 ```sh
-yarn add react-native-activestorage rn-fetch-blob
+yarn add react-native-activestorage react-native-blob-util
 ```
 
 ## Usage
@@ -105,4 +105,4 @@ directUpload({ file, directUploadsUrl, onStatusChange });
 The package is available as open source under the terms of the [MIT License][license].
 
 [license]: https://raw.githubusercontent.com/jpalumickas/react-native-activestorage/master/LICENSE
-[rn-fetch-blob]: https://github.com/joltup/rn-fetch-blob
+[react-native-blob-util]: https://www.npmjs.com/package/react-native-blob-util

--- a/package.json
+++ b/package.json
@@ -20,9 +20,9 @@
     "abab": "^2.0.5"
   },
   "peerDependencies": {
-    "react": ">=16.8",
-    "react-native": ">= 0.60.0",
-    "rn-fetch-blob": ">= 0.10.0"
+    "react": ">= 17.0.2",
+    "react-native": ">= 0.65.0",
+    "react-native-blob-util": ">= 0.17.3"
   },
   "devDependencies": {
     "@types/react": "^17.0.9",
@@ -30,7 +30,7 @@
     "microbundle": "^0.13.1",
     "prettier": "^2.3.1",
     "rimraf": "^3.0.2",
-    "rn-fetch-blob": "^0.12.0"
+    "react-native-blob-util": "^0.17.3"
   },
   "scripts": {
     "build": "rimraf dist && microbundle -f modern,esm,cjs --jsx React.createElement",

--- a/src/lib/checksum.ts
+++ b/src/lib/checksum.ts
@@ -1,8 +1,8 @@
-import RNFetchBlob from 'rn-fetch-blob';
+import ReactNativeBlobUtil from 'react-native-blob-util';
 import { btoa } from 'abab';
 
 const checksum = async ({ path }: { path: string }) => {
-  const md5 = await RNFetchBlob.fs.hash(path, 'md5');
+  const md5 = await ReactNativeBlobUtil.fs.hash(path, 'md5');
   const hexArray = md5.replace(/\r|\n/g, "")
     .replace(/([\da-fA-F]{2}) ?/g, "0x$1 ")
     .replace(/ +$/, "")

--- a/src/lib/directUpload.ts
+++ b/src/lib/directUpload.ts
@@ -1,4 +1,4 @@
-import RNFetchBlob, { FetchBlobResponse, StatefulPromise } from 'rn-fetch-blob';
+import ReactNativeBlobUtil, { FetchBlobResponse, StatefulPromise } from 'react-native-blob-util';
 import createBlobRecord from './createBlobRecord';
 import { File, DirectUploadResult, HandleStatusUpdateData } from '../types';
 
@@ -41,9 +41,9 @@ const directUpload = ({ directUploadsUrl, file, headers, onStatusChange }: Direc
 
       const { url, headers: uploadHeaders } = blobData.direct_upload;
 
-      const fileData = RNFetchBlob.wrap(file.path);
+      const fileData = ReactNativeBlobUtil.wrap(file.path);
 
-      task = RNFetchBlob.fetch('PUT', url, uploadHeaders, fileData);
+      task = ReactNativeBlobUtil.fetch('PUT', url, uploadHeaders, fileData);
 
       task
         .uploadProgress({ interval: 250 }, (uploadedBytes, totalBytes) => {

--- a/yarn.lock
+++ b/yarn.lock
@@ -1805,18 +1805,6 @@ get-intrinsic@^1.0.2, get-intrinsic@^1.1.1:
     has "^1.0.3"
     has-symbols "^1.0.1"
 
-glob@7.0.6:
-  version "7.0.6"
-  resolved "https://registry.yarnpkg.com/glob/-/glob-7.0.6.tgz#211bafaf49e525b8cd93260d14ab136152b3f57a"
-  integrity sha1-IRuvr0nlJbjNkyYNFKsTYVKz9Xo=
-  dependencies:
-    fs.realpath "^1.0.0"
-    inflight "^1.0.4"
-    inherits "2"
-    minimatch "^3.0.2"
-    once "^1.3.0"
-    path-is-absolute "^1.0.0"
-
 glob@^7.1.3, glob@^7.1.6:
   version "7.1.7"
   resolved "https://registry.yarnpkg.com/glob/-/glob-7.1.7.tgz#3b193e9233f01d42d0b3f78294bbeeb418f94a90"
@@ -1826,6 +1814,18 @@ glob@^7.1.3, glob@^7.1.6:
     inflight "^1.0.4"
     inherits "2"
     minimatch "^3.0.4"
+    once "^1.3.0"
+    path-is-absolute "^1.0.0"
+
+glob@^7.2.3:
+  version "7.2.3"
+  resolved "https://registry.yarnpkg.com/glob/-/glob-7.2.3.tgz#b8df0fb802bbfa8e89bd1d938b4e16578ed44f2b"
+  integrity sha512-nFR0zLpU2YCaRxwoCJvL6UvCH2JFyFVIvwTLsIf21AuHlMskA1hhTdk+LlYJtOlYt9v6dvszD2BGRqBL+iQK9Q==
+  dependencies:
+    fs.realpath "^1.0.0"
+    inflight "^1.0.4"
+    inherits "2"
+    minimatch "^3.1.1"
     once "^1.3.0"
     path-is-absolute "^1.0.0"
 
@@ -2281,10 +2281,17 @@ microbundle@^0.13.1:
     tslib "^2.0.3"
     typescript "^4.1.3"
 
-minimatch@^3.0.2, minimatch@^3.0.4:
+minimatch@^3.0.4:
   version "3.0.4"
   resolved "https://registry.yarnpkg.com/minimatch/-/minimatch-3.0.4.tgz#5166e286457f03306064be5497e8dbb0c3d32083"
   integrity sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==
+  dependencies:
+    brace-expansion "^1.1.7"
+
+minimatch@^3.1.1:
+  version "3.1.2"
+  resolved "https://registry.yarnpkg.com/minimatch/-/minimatch-3.1.2.tgz#19cd194bfd3e428f049a70817c038d89ab4be35b"
+  integrity sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==
   dependencies:
     brace-expansion "^1.1.7"
 
@@ -2868,6 +2875,14 @@ randombytes@^2.1.0:
   dependencies:
     safe-buffer "^5.1.0"
 
+react-native-blob-util@^0.17.3:
+  version "0.17.3"
+  resolved "https://registry.yarnpkg.com/react-native-blob-util/-/react-native-blob-util-0.17.3.tgz#5dead89807ec176828a91c815c276da2e5c71fea"
+  integrity sha512-nO4VXIPtCrtf3mzCiOkdrXsmc8WmOLNSziS7dCnQ6kSyg4LOLXP4mQOFqfiNxt78n7cZ0QOF5CdUY/sIZZ2aOA==
+  dependencies:
+    base-64 "0.1.0"
+    glob "^7.2.3"
+
 regenerate-unicode-properties@^8.2.0:
   version "8.2.0"
   resolved "https://registry.yarnpkg.com/regenerate-unicode-properties/-/regenerate-unicode-properties-8.2.0.tgz#e5de7111d655e7ba60c057dbe9ff37c87e65cdec"
@@ -2962,14 +2977,6 @@ rimraf@^3.0.2:
   integrity sha512-JZkJMZkAGFFPP2YqXZXPbMlMBgsxzE8ILs4lMIX/2o0L9UBw9O/Y3o6wFw/i9YLapcUJWwqbi3kdxIPdC62TIA==
   dependencies:
     glob "^7.1.3"
-
-rn-fetch-blob@^0.12.0:
-  version "0.12.0"
-  resolved "https://registry.yarnpkg.com/rn-fetch-blob/-/rn-fetch-blob-0.12.0.tgz#ec610d2f9b3f1065556b58ab9c106eeb256f3cba"
-  integrity sha512-+QnR7AsJ14zqpVVUbzbtAjq0iI8c9tCg49tIoKO2ezjzRunN7YL6zFSFSWZm6d+mE/l9r+OeDM3jmb2tBb2WbA==
-  dependencies:
-    base-64 "0.1.0"
-    glob "7.0.6"
 
 rollup-plugin-bundle-size@^1.0.3:
   version "1.0.3"


### PR DESCRIPTION
rn-fetch-blob is no longer actively maintained, [react-native-blob-util](https://www.npmjs.com/package/react-native-blob-util) is a fork of rn-fetch-blob that is actively maintained